### PR TITLE
Added protocol version

### DIFF
--- a/bluesky.py
+++ b/bluesky.py
@@ -7,6 +7,8 @@ from signal import pause
 moving = False
 import skywriter
 
+BD_PROTOCOL_VERSION = 1
+
 # robot runs the bluedot server
 bd_server = 'artipi'
 #bd_server = 'BlueZ 5.43'
@@ -56,6 +58,8 @@ def data_received(data):
 
 print("Connecting to {}".format(bd_server))
 c = BluetoothClient(bd_server, data_received)
+print("Sending protocol version")
+c.send("3,{},BlueSky\n".format(BD_PROTOCOL_VERSION))
 print("  Connected to {}".format(bd_server))
 
 #print("Sending")


### PR DESCRIPTION
For your BlueSky project to work with newer versions of the bluedot library it will need to send a protocol version when the client has connected.

If no protocol version is sent, the BlueDot server will disconnect the client with a "please update your client" error.

I cant test this PR (no skywriter HAT) but it should work.